### PR TITLE
add camera screen and its functionality

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,7 @@
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { StatusBar } from "expo-status-bar";
+import CameraScreen from "./screens/CameraScreen";
 import Home from "./screens/HomeScreen";
 import LogIn from "./screens/LogInScreen";
 import NewProjectScreen from "./screens/NewProjectScreen";
@@ -21,6 +22,7 @@ export type RootStackParamList = {
   ProjectNavigation: undefined;
   Projects: undefined;
   SignIn: undefined;
+  CameraScreen: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -39,6 +41,7 @@ export default function App() {
         <Stack.Screen name="ProjectNavigation" component={ProjectNavigation} />
         <Stack.Screen name="NewProject" component={NewProjectScreen} />
         <Stack.Screen name="Projects" component={Projects} />
+        <Stack.Screen name="CameraScreen" component={CameraScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-navigation/native": "^6.0.13",
         "@react-navigation/native-stack": "^6.9.0",
         "expo": "~46.0.9",
+        "expo-camera": "~12.3.0",
         "expo-image-picker": "~13.3.1",
         "expo-status-bar": "~1.4.0",
         "react": "18.0.0",
@@ -6015,6 +6016,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/dequal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-1.0.1.tgz",
+      "integrity": "sha512-Fx8jxibzkJX2aJgyfSdLhr9tlRoTnHKrRJuu2XHlAgKioN2j19/Bcbe0d4mFXYZ3+wpE2KVobUVTfDutcD17xQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -6375,6 +6384,44 @@
         "md5-file": "^3.2.3",
         "path-browserify": "^1.0.0",
         "url-parse": "^1.5.9"
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-12.3.0.tgz",
+      "integrity": "sha512-niQ2kywvhLYzK0zj+8Xq5q77eeA10MdauKg7RKWGMNehht33uOXTP1pzAXwcPbQ0De3nRmddIlRQkkxV8ey7YQ==",
+      "dependencies": {
+        "@expo/config-plugins": "~5.0.0",
+        "@koale/useworker": "^4.0.2",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-camera/node_modules/@koale/useworker": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@koale/useworker/-/useworker-4.0.2.tgz",
+      "integrity": "sha512-xPIPADtom8/3/4FLNj7MvNcBM/Z2FleH85Fdx2O869eoKW8+PoEgtSVvoxWjCWMA46Sm9A5/R1TyzNGc+yM0wg==",
+      "dependencies": {
+        "dequal": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0"
+      }
+    },
+    "node_modules/expo-camera/node_modules/react": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expo-constants": {
@@ -10130,6 +10177,23 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -16994,6 +17058,11 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ=="
     },
+    "dequal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-1.0.1.tgz",
+      "integrity": "sha512-Fx8jxibzkJX2aJgyfSdLhr9tlRoTnHKrRJuu2XHlAgKioN2j19/Bcbe0d4mFXYZ3+wpE2KVobUVTfDutcD17xQ=="
+    },
     "destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -17276,6 +17345,37 @@
         "md5-file": "^3.2.3",
         "path-browserify": "^1.0.0",
         "url-parse": "^1.5.9"
+      }
+    },
+    "expo-camera": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-12.3.0.tgz",
+      "integrity": "sha512-niQ2kywvhLYzK0zj+8Xq5q77eeA10MdauKg7RKWGMNehht33uOXTP1pzAXwcPbQ0De3nRmddIlRQkkxV8ey7YQ==",
+      "requires": {
+        "@expo/config-plugins": "~5.0.0",
+        "@koale/useworker": "^4.0.2",
+        "invariant": "^2.2.4"
+      },
+      "dependencies": {
+        "@koale/useworker": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/@koale/useworker/-/useworker-4.0.2.tgz",
+          "integrity": "sha512-xPIPADtom8/3/4FLNj7MvNcBM/Z2FleH85Fdx2O869eoKW8+PoEgtSVvoxWjCWMA46Sm9A5/R1TyzNGc+yM0wg==",
+          "requires": {
+            "dequal": "^1.0.0"
+          }
+        },
+        "react": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+          "peer": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        }
       }
     },
     "expo-constants": {
@@ -20137,6 +20237,25 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "peer": true
+        }
       }
     },
     "pump": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react-native-web": "~0.18.7",
     "react-native-screens": "~3.15.0",
     "react-native-safe-area-context": "4.3.1",
-    "expo-image-picker": "~13.3.1"
+    "expo-image-picker": "~13.3.1",
+    "expo-camera": "~12.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/screens/CameraScreen.tsx
+++ b/screens/CameraScreen.tsx
@@ -10,7 +10,7 @@ import {
   View,
 } from "react-native";
 
-export default function App() {
+export default function CameraScreen() {
   const [type, setType] = useState(CameraType.front);
   const [permission, requestPermission] = Camera.useCameraPermissions();
   const [camera, setCamera] = useState<Camera>();

--- a/screens/CameraScreen.tsx
+++ b/screens/CameraScreen.tsx
@@ -1,0 +1,112 @@
+import { AntDesign } from "@expo/vector-icons";
+import { Camera, CameraCapturedPicture, CameraType } from "expo-camera";
+import React, { useState } from "react";
+import {
+  Button,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+export default function App() {
+  const [type, setType] = useState(CameraType.front);
+  const [permission, requestPermission] = Camera.useCameraPermissions();
+  const [camera, setCamera] = useState<Camera>();
+  const [image, setImage] = useState<CameraCapturedPicture>();
+
+  if (!permission) {
+    return <View />;
+  }
+
+  if (!permission.granted) {
+    return (
+      <View style={styles.container}>
+        <Text style={{ textAlign: "center" }}>
+          We need your permission to show the camera
+        </Text>
+        <Button onPress={requestPermission} title="grant permission" />
+      </View>
+    );
+  }
+
+  const takePicture = async () => {
+    if (camera) {
+      const data = await camera.takePictureAsync({});
+      setImage(data);
+    }
+  };
+
+  function toggleCameraType() {
+    setType((current) =>
+      current === CameraType.back ? CameraType.front : CameraType.back
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Camera
+        style={styles.camera}
+        type={type}
+        ref={(ref: Camera) => {
+          setCamera(ref);
+        }}
+      >
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity style={styles.button} onPress={toggleCameraType}>
+            <Text style={styles.text}>Flip Camera</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.icon} onPress={takePicture}>
+            <AntDesign name="caretcircleoup" size={96} color="black" />
+          </TouchableOpacity>
+        </View>
+        <Image source={{ uri: image?.uri }} style={styles.smallImage} />
+      </Camera>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    position: "relative",
+  },
+  camera: {
+    flex: 1,
+  },
+  buttonContainer: {
+    flex: 1,
+    flexDirection: "column",
+    backgroundColor: "transparent",
+    margin: 64,
+  },
+  button: {
+    flex: 1,
+    alignSelf: "center",
+    alignItems: "center",
+    position: "absolute",
+    bottom: 5,
+    left: 0,
+  },
+  icon: {
+    flex: 1,
+    alignSelf: "center",
+    alignItems: "center",
+    position: "absolute",
+    bottom: 50,
+  },
+  text: {
+    fontSize: 24,
+    fontWeight: "bold",
+    color: "white",
+  },
+  smallImage: {
+    position: "absolute",
+    bottom: 20,
+    right: 20,
+    width: 100,
+    height: 100,
+  },
+});


### PR DESCRIPTION
close #35 

På bilden nedan ser ni hur det såg ut på min mobil, en del små stylingar osv som ska ändras med tiden, men nu finns camera screen och går att använda iaf.
På bilden ser ni en svart ikon nere i mitten som man trycker på för att ta en bild.
Snett nedanför till höger om den ikonen kommer en liten preview på bilden som man tog.
Till vänster står det för tillfället bara Flip Camera, men denna bör kanske bytas ut till en lämplig ikon.
Just nu finns inte funktionaliteten för att bilden ska läggas till en flatlist, men tänker att det kommer senare

![image](https://user-images.githubusercontent.com/90764566/192267866-1ed26839-6d58-49e8-b0aa-ac96ea85f3e5.png)
